### PR TITLE
Remove SendGrid template_id length-check for 36 chars

### DIFF
--- a/lib/bamboo/adapters/send_grid_helper.ex
+++ b/lib/bamboo/adapters/send_grid_helper.ex
@@ -12,7 +12,6 @@ defmodule Bamboo.SendGridHelper do
 
   alias Bamboo.Email
 
-  @id_size 36
   @field_name :send_grid_template
   @categories :categories
 
@@ -26,16 +25,10 @@ defmodule Bamboo.SendGridHelper do
       |> with_template("80509523-83de-42b6-a2bf-54b7513bd2aa")
   """
   def with_template(email, template_id) do
-    if byte_size(template_id) == @id_size do
-      template = Map.get(email.private, @field_name, %{})
+    template = Map.get(email.private, @field_name, %{})
 
-      email
-      |> Email.put_private(@field_name, set_template(template, template_id))
-    else
-      raise "expected the template_id parameter to be a UUID 36 characters long, got #{
-              template_id
-            }"
-    end
+    email
+    |> Email.put_private(@field_name, set_template(template, template_id))
   end
 
   @doc """

--- a/test/lib/bamboo/adapters/sendgrid_helper_test.exs
+++ b/test/lib/bamboo/adapters/sendgrid_helper_test.exs
@@ -14,12 +14,6 @@ defmodule Bamboo.SendGridHelperTest do
     assert email.private[:send_grid_template] == %{template_id: @template_id}
   end
 
-  test "with_template/2 raises on non-UUID `template_id`", %{email: email} do
-    assert_raise RuntimeError, fn ->
-      email |> with_template("not a UUID")
-    end
-  end
-
   test "with_template/2 uses the last specified template", %{email: email} do
     last_template_id = "355d0197-ecf5-4268-aa8b-2c0502aec406"
     email = email |> with_template(@template_id) |> with_template(last_template_id)


### PR DESCRIPTION
Not all SendGrid template_ids are UUIDs anymore